### PR TITLE
PR 병합 시 status 라벨 변경 자동화

### DIFF
--- a/.github/workflows/status-labels-on-merge.yml
+++ b/.github/workflows/status-labels-on-merge.yml
@@ -1,0 +1,108 @@
+name: Update Status Labels on PR Merge
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  update_status_labels:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Check Repository Labels
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'status:done'
+              });
+            } catch (error) {
+              if (error.status === 404) {
+                console.error(`'status:done' 라벨이 저장소에 존재하지 않습니다.`);
+                return;
+              }
+              console.error('라벨 확인 중 오류:', error);
+            }
+
+      - name: Update PR and Issue Labels
+        if: success()
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            async function updateStatusLabels(issueNumber, currentLabels) {
+              const statusLabels = currentLabels.filter(label => label.name.startsWith('status:'));
+              
+              // status:done이 아닌 status: 라벨 제거
+              await Promise.all(statusLabels
+                .filter(label => label.name !== 'status:done')
+                .map(label => github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: label.name
+                }).catch(error => {
+                  if (error.status !== 404) console.error(`라벨 ${label.name} 제거 중 오류:`, error);
+                }))
+              );
+
+              // status:done 라벨 추가
+              if (!statusLabels.some(label => label.name === 'status:done')) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  labels: ['status:done']
+                });
+              }
+
+              const { data: finalLabels } = await github.rest.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber
+              });
+              return finalLabels.map(label => label.name);
+            }
+
+            try {
+              // PR 라벨 업데이트
+              const prNumber = context.payload.pull_request.number;
+              const prFinalLabels = await updateStatusLabels(prNumber, context.payload.pull_request.labels);
+              console.log(`PR #${prNumber} 최종 라벨:`, prFinalLabels);
+
+              // 연결된 이슈 찾기
+              const prBody = context.payload.pull_request.body;
+              if (!prBody) return;
+
+              const issueRegex = /(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#(\d+)/gi;
+              const uniqueIssueNumbers = new Set([...prBody.matchAll(issueRegex)].map(match => match[2]));
+              
+              if (uniqueIssueNumbers.size === 0) return;
+
+              // 이슈 라벨 업데이트
+              await Promise.all(Array.from(uniqueIssueNumbers).map(async issueNumber => {
+                try {
+                  const { data: issue } = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber
+                  });
+
+                  const finalLabels = await updateStatusLabels(issueNumber, issue.labels);
+                  console.log(`이슈 #${issueNumber} 최종 라벨:`, finalLabels);
+                } catch (error) {
+                  if (error.status !== 404) {
+                    console.error(`이슈 #${issueNumber} 처리 중 오류:`, error);
+                  }
+                }
+              }));
+            } catch (error) {
+              console.error('라벨 업데이트 중 오류:', error);
+            }


### PR DESCRIPTION
## 관련 이슈 번호
<!-- 관련된 이슈 번호(ex-#01)를 명시해 주세요. -->
Resolves #18 

## 핵심 변경 사항 및 이유
<!-- 이번 PR에서 작업한 주요 변경 사항과 그 이유를 간단히 설명해 주세요. -->
- PR 병합 시 status 라벨 변경 자동화하는 Github Action
  - PR 병합 시 자동으로 status 라벨을 관리하여 누락 방지
  - PR과 함께 close되는 이슈의 status 라벨을 자동으로 `status:done`으로 변경
  - status 라벨만 제거되고 다른 타입의 라벨은 유지됨                                                     

## PR 시 참고 사항 (선택) 
<!-- 이 PR을 이해하거나 테스트하기 위해 알아야 할 추가 정보나 주의사항을 작성해 주세요. -->
- PR이 병합될 때만 동작하며, 직접 merge하는 경우는 적용되지 않음
- 이슈를 close하는 키워드(close, fix, resolves 등)가 있는 경우에만 해당 이슈의 라벨이 업데이트됨

