### PR TITLE
오프셋 기반 게시글 목록 조회 및 페이지네이션 추가

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,21 +3,24 @@ import Link from 'next/link';
 
 import { getInfiniteScrollData } from '@/features/post/post-list';
 import { PostInfiniteScroll } from '@/features/post/post-list';
+import { PostListPagination } from '@/features/post/post-list/ui/post-list-pagination';
 
 export default async function Home() {
   const { data, nextCursor, hasMore } = await getInfiniteScrollData('', 10);
 
   return (
-    <>
+    <main className="mx-auto max-w-4xl p-6">
       <Button asChild>
         <Link href="/posts/write">새 글 작성</Link>
       </Button>
+
+      <PostListPagination />
 
       <PostInfiniteScroll
         postList={data}
         lastPostId={nextCursor}
         hasMore={hasMore}
       />
-    </>
+    </main>
   );
 }

--- a/apps/web/entities/post/api/post-api.ts
+++ b/apps/web/entities/post/api/post-api.ts
@@ -1,4 +1,9 @@
-import type { CreatePostDTO, Post, UpdatePostDTO } from '@/entities/post';
+import type {
+  CreatePostDTO,
+  GetPostsOffset,
+  Post,
+  UpdatePostDTO,
+} from '@/entities/post';
 import { httpClient } from '@/shared/api';
 
 // 게시글 생성 (POST /posts)
@@ -37,4 +42,14 @@ export const deletePost = async (
   return httpClient<{ message: string }>(`/posts/${postId}`, {
     method: 'DELETE',
   });
+};
+
+// 오프셋 기반 게시글 목록 조회 (현재 페이지와 전체 페이지 정보 포함)
+export const getPostsByPage = async (
+  page: number = 1,
+  limit: number = 10
+): Promise<GetPostsOffset> => {
+  return httpClient<GetPostsOffset>(
+    `/posts/paginated?page=${page}&limit=${limit}`
+  );
 };

--- a/apps/web/entities/post/index.ts
+++ b/apps/web/entities/post/index.ts
@@ -1,4 +1,10 @@
-export { createPost, getPostById, getPosts, updatePost } from './api/post-api';
+export {
+  createPost,
+  getPostById,
+  getPosts,
+  getPostsByPage,
+  updatePost,
+} from './api/post-api';
 export { ERROR_MESSAGES } from './lib/error-messages';
 export {
   extractFormData,
@@ -9,7 +15,9 @@ export {
 export type {
   CreatePostDTO,
   GetPostsCursor,
+  GetPostsOffset,
   Post,
   UpdatePostDTO,
 } from './model/post-types';
+export type { PostViewModel } from './model/post-view-model';
 export { mapPostToViewModel } from './model/post-view-model';

--- a/apps/web/entities/post/lib/error-messages.ts
+++ b/apps/web/entities/post/lib/error-messages.ts
@@ -1,4 +1,5 @@
 export const ERROR_MESSAGES = {
+  FETCH_FAILED: '게시글을 불러오는 데 실패했습니다',
   INVALID_TYPE: '유효하지 않은 입력 형식입니다.',
   INVALID_ID: '유효하지 않은 게시글 입니다.',
   REQUIRED_TITLE: '제목을 입력해주세요',

--- a/apps/web/features/post/post-list/index.ts
+++ b/apps/web/features/post/post-list/index.ts
@@ -1,3 +1,4 @@
 export { getInfiniteScrollData } from './api/post-infinite-scroll';
 export { PostInfiniteScroll } from './ui/post-infinite-scroll';
 export { PostItem } from './ui/post-item';
+export { PostListPagination } from './ui/post-list-pagination';

--- a/apps/web/features/post/post-list/ui/post-list-pagination.tsx
+++ b/apps/web/features/post/post-list/ui/post-list-pagination.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { Button } from '@workspace/ui/components/button';
-import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import {
@@ -14,7 +12,6 @@ import { PostItem } from '@/features/post/post-list';
 import { usePagination } from '@/shared/hooks/usePagination';
 
 export function PostListPagination() {
-  const router = useRouter();
   const [posts, setPosts] = useState<PostViewModel[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -45,29 +42,22 @@ export function PostListPagination() {
 
   return (
     <div className="flex flex-col items-center">
-      <h1 className="my-4 text-2xl font-bold">게시글 목록</h1>
-      <div className="flex w-full max-w-4xl flex-col gap-4">
-        <div className="flex justify-end">
-          <Button onClick={() => router.push('/posts/write')}>글쓰기</Button>
-        </div>{' '}
-        <ul className="w-full">
-          {isLoading ? (
-            <p className="text-center text-gray-500">로딩 중...</p>
-          ) : (
-            posts.map((post) => (
-              <PostItem
-                key={post.id}
-                linkPostId={post.id}
-                title={post.title}
-                content={post.content}
-                author={post.author}
-                localeCreatedAt={post.localeCreatedAt}
-              />
-            ))
-          )}
-        </ul>
-      </div>
-      {/* 페이지네이션 */}
+      <ul className="w-full">
+        {isLoading ? (
+          <p className="text-center text-gray-500">로딩 중...</p>
+        ) : (
+          posts.map((post) => (
+            <PostItem
+              key={post.id}
+              linkPostId={post.id}
+              title={post.title}
+              content={post.content}
+              author={post.author}
+              localeCreatedAt={post.localeCreatedAt}
+            />
+          ))
+        )}
+      </ul>
       <div className="mt-6 flex items-center gap-2">{paginationButtons}</div>
     </div>
   );

--- a/apps/web/features/post/post-list/ui/post-list-pagination.tsx
+++ b/apps/web/features/post/post-list/ui/post-list-pagination.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Button } from '@workspace/ui/components/button';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import {
+  ERROR_MESSAGES,
+  getPostsByPage,
+  mapPostToViewModel,
+  PostViewModel,
+} from '@/entities/post';
+import { PostItem } from '@/features/post/post-list';
+import { usePagination } from '@/shared/hooks/usePagination';
+
+export function PostListPagination() {
+  const router = useRouter();
+  const [posts, setPosts] = useState<PostViewModel[]>([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [isLoading, setIsLoading] = useState(false);
+  const postsPerPage = 10;
+
+  const { paginationButtons } = usePagination(
+    currentPage,
+    totalPages,
+    setCurrentPage
+  );
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      setIsLoading(true);
+      try {
+        const response = await getPostsByPage(currentPage, postsPerPage);
+        setPosts(response.data.map(mapPostToViewModel));
+        setTotalPages(response.totalPages);
+      } catch (error) {
+        console.error(`❌ ${ERROR_MESSAGES.FETCH_FAILED}:`, error);
+      }
+      setIsLoading(false);
+    };
+
+    fetchPosts();
+  }, [currentPage]);
+
+  return (
+    <div className="flex flex-col items-center">
+      <h1 className="my-4 text-2xl font-bold">게시글 목록</h1>
+      <div className="flex w-full max-w-4xl flex-col gap-4">
+        <div className="flex justify-end">
+          <Button onClick={() => router.push('/posts/write')}>글쓰기</Button>
+        </div>{' '}
+        <ul className="w-full">
+          {isLoading ? (
+            <p className="text-center text-gray-500">로딩 중...</p>
+          ) : (
+            posts.map((post) => (
+              <PostItem
+                key={post.id}
+                linkPostId={post.id}
+                title={post.title}
+                content={post.content}
+                author={post.author}
+                localeCreatedAt={post.localeCreatedAt}
+              />
+            ))
+          )}
+        </ul>
+      </div>
+      {/* 페이지네이션 */}
+      <div className="mt-6 flex items-center gap-2">{paginationButtons}</div>
+    </div>
+  );
+}

--- a/apps/web/shared/hooks/index.ts
+++ b/apps/web/shared/hooks/index.ts
@@ -1,0 +1,1 @@
+export { usePagination } from './usePagination';

--- a/apps/web/shared/hooks/usePagination.tsx
+++ b/apps/web/shared/hooks/usePagination.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from 'react';
+
+export function usePagination(
+  currentPage: number,
+  totalPages: number,
+  setPage: (page: number) => void
+) {
+  const maxPageButtons = 5;
+  const currentGroup = Math.floor((currentPage - 1) / maxPageButtons);
+  const startPage = currentGroup * maxPageButtons + 1;
+  const endPage = Math.min(startPage + maxPageButtons - 1, totalPages);
+
+  const paginationButtons = useMemo(
+    () =>
+      [
+        { label: '<<', page: 1, isNav: true, disabled: currentPage === 1 },
+        {
+          label: '<',
+          page: Math.max(startPage - 1, 1),
+          isNav: true,
+          disabled: currentPage === 1,
+        },
+        ...Array.from({ length: endPage - startPage + 1 }).map((_, idx) => ({
+          label: (startPage + idx).toString(),
+          page: startPage + idx,
+          isNav: false,
+          disabled: currentPage === startPage + idx,
+        })),
+        {
+          label: '>',
+          page: Math.min(startPage + maxPageButtons, totalPages),
+          isNav: true,
+          disabled: currentPage === totalPages,
+        },
+        {
+          label: '>>',
+          page: totalPages,
+          isNav: true,
+          disabled: currentPage === totalPages,
+        },
+      ].map(({ label, page, isNav, disabled }) => (
+        <button
+          key={label}
+          onClick={() => !disabled && setPage(page)}
+          disabled={disabled}
+          className={`rounded-md border px-3 py-1 transition ${
+            disabled
+              ? isNav
+                ? 'text-gray-400' // <<, <, >, >> 버튼이 비활성화되면 글씨만 회색
+                : 'bg-gray-900 text-white underline' // 페이지 번호 버튼이 비활성화되면 배경 변경
+              : currentPage === page
+                ? 'bg-black font-bold text-white underline' // 현재 페이지 버튼 스타일
+                : 'bg-white hover:bg-gray-100' // 기본 버튼 스타일
+          }`}
+        >
+          {label}
+        </button>
+      )),
+    [currentPage, endPage, setPage, startPage, totalPages]
+  );
+
+  return { paginationButtons, goToPage: setPage };
+}


### PR DESCRIPTION
## 관련 이슈 번호
<!-- 관련된 이슈 번호(ex-#01)를 명시해 주세요. -->
#21 

## 핵심 변경 사항 및 이유
<!-- 이번 PR에서 작업한 주요 변경 사항과 그 이유를 간단히 설명해 주세요. -->
- 오프셋 기반 게시글 조회 API 추가
  - 오프셋 기반 페이지네이션(`getPostsByPage`)을 사용할 수 있도록 기능 추가
  - 관련 타입(`GetPostsOffset`) 추가
  - 에러 핸들링을 위해 ERROR_MESSAGES.FETCH_FAILED 추가
- 공통 페이지네이션 훅 (`usePagination`) 추가
  - 게시글 목록에서 재사용할 수 있는 페이지네이션 훅을 구현
  - 최대 5개 페이지 버튼을 보여주고, <, > 버튼을 통해 페이지 이동 가능
- 페이지네이션 방식의 게시글 목록 (`PostListPagination`) 추가
  - `usePagination `훅을 활용하여 페이지네이션을 적용한 게시글 목록 UI 구현
  - 기존 PostItem 컴포넌트를 활용하여 렌더링


## 이외 기타 변경 사항
<!-- 주요 변경 사항 외에 추가로 수정되거나 영향을 받은 부분을 작성해 주세요. -->
- app/page.tsx에서 <PostListPagination /> 추가
- features/post/post-list/index.ts에 PostListPagination 추가

## PR 시 참고 사항
<!-- 이 PR을 이해하거나 테스트하기 위해 알아야 할 추가 정보나 주의사항을 작성해 주세요. -->
- 현재 feature/post-detail 브랜치에서도 작업 중이기 떄문에 feature-group/post에 머지하면 충돌을 해결해야 함
- 기존 무한 스크롤 방식(PostInfiniteScroll)과 페이지네이션 방식(PostListPagination)이 함께 존재하므로, 이후 선택적으로 유지 여부를 결정해야 함

## 관련 스크린샷
<!-- UI 변경 사항이 있다면 Before/After 스크린샷을 첨부해 주세요. -->
![image](https://github.com/user-attachments/assets/d732a52a-76a5-49f3-9f4f-716ca7886a0f)
